### PR TITLE
Stricter grammar rules for matching add instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ And it will print the following to stdout:
 
 ## Some caveats about compliance with the informal spec
 - It's entirely possible at this point that some of my implementation deviates from the spec in unintended ways. If you spot anything like that, please raise an issue :heart: :heart:
-- There are rules for the words 'like' and 'as' that I've taken to mean simply the presence of the patterns 'like' or 'as'. So the rule for 'like' has the potential to match 'likes' and 'has' to match the rule for 'as' (barring any other rule that takes precedence).
 - Comments are not a part of the spec but are implemented in this version. They are denoted by lines beginning with the `;;` characters. For now, they will have an effect on the execution unless they are put at the end of the source file.
 - As I've read it, the rule for 'storing syllables' used in the title has less precedence that the rest of the rules, that means, for a program to successfully consume input, there must be no others instructions present.
 - The alliteration and rhyming rules are still unimplemented.

--- a/ashpaper/src/grammar.pest
+++ b/ashpaper/src/grammar.pest
@@ -22,7 +22,7 @@ register0 = { start }
 goto  = { any_not_forward_slash* ~ "/" ~ any* ~ end }
 negate = { any_not_caps_in_word* ~ caps_in_word ~ any* ~ end }
 multiply = { (uppercase_letter | (any_not_title_case* ~ title_case)) ~ any* ~ end }
-add = { like_lit | as_lit }
+add = { like_all | as_all }
 print_char =  { any_not_question* ~ question ~ any* ~ end }
 print_value =  { any_not_dot* ~ dot ~ any* ~ end }
 pop =  { any_not_comma* ~ comma ~ any* ~ end }
@@ -39,11 +39,37 @@ any_not_caps_in_word = _{ !caps_in_word ~ any }
 title_case = _{ whitespace ~ uppercase_letter }
 any_not_title_case = _{ !title_case ~ any }
 
-like_lit = _{ any_not_like* ~ "like" ~ any* ~ end }
-any_not_like = _{ !"like" ~ any }
+like_all = _{ like1_full | like2_full | like3_full | like4_full }
 
-as_lit = _{ any_not_as* ~ "as" ~ any* ~ end }
-any_not_as = _{ !"as" ~ any }
+like1_full = _{ any_not_like1* ~ like1 ~ any* ~ end }
+like2_full = _{ any_not_like2* ~ like2 ~ end }
+like3_full = _{ like3 ~ any* ~ end }
+like4_full = _{ like4 ~ end }
+
+like1 = _{ punctuation_or_ws ~ "like" ~ punctuation_or_ws }
+like2 = _{ punctuation_or_ws ~ "like" }
+like3 = _{ "like" ~ punctuation_or_ws }
+like4 = _{ "like" }
+any_not_like1 = _{ !like1 ~ any }
+any_not_like2 = _{ !like2 ~ any }
+any_not_like3 = _{ !like3 ~ any }
+
+as_all = _{ as1_full | as2_full | as3_full | as4_full }
+
+as1_full = _{ any_not_as1* ~ as1 ~ any* ~ end }
+as2_full = _{ any_not_as2* ~ as2 ~ end }
+as3_full = _{ as3 ~ any* ~ end }
+as4_full = _{ as4 ~ end }
+
+as1 = _{ punctuation_or_ws ~ "as" ~ punctuation_or_ws }
+as2 = _{ punctuation_or_ws ~ "as" }
+as3 = _{ "as" ~ punctuation_or_ws }
+as4 = _{ "as" }
+any_not_as1 = _{ !as1 ~ any }
+any_not_as2 = _{ !as2 ~ any }
+any_not_as3 = _{ !as3 ~ any }
+
+punctuation_or_ws = _{ PUNCTUATION | whitespace }
 
 question = _{ "?" }
 any_not_question = _{ !question ~ any }

--- a/ashpaper/src/lib.rs
+++ b/ashpaper/src/lib.rs
@@ -47,8 +47,7 @@
 /// ```
 ///
 /// ## Some caveats about compliance with the informal spec
-/// - The wording around when to use a specific register vs. the active register has lead me to make some choices. While I've attempted to reproduce the behavior of the author's implementation, you may discover that it deviates. If you do, please raise an issue :heart: :heart:
-/// - There are rules for the words 'like' and 'as' that I've taken to mean simply the presence of the patterns 'like' or 'as'. So the rule for 'like' has the potential to match 'likes' and 'has' to match the rule for 'as' (barring any other rule that takes precedence).
+/// - It's entirely possible at this point that some of my implementation deviates from the spec in unintended ways. If you spot anything like that, please raise an issue :heart: :heart:
 /// - Comments are not a part of the spec but are implemented in this version. They are denoted by lines beginning with the `;;` characters. For now, they will have an effect on the execution unless they are put at the end of the source file.
 /// - As I've read it, the rule for 'storing syllables' used in the title has less precedence that the rest of the rules, that means, for a program to successfully consume input, there must be no others instructions present.
 /// - The alliteration and rhyming rules are still unimplemented.

--- a/ashpaper/src/program.rs
+++ b/ashpaper/src/program.rs
@@ -232,6 +232,16 @@ mod tests {
         assert_eq!(rule, res)
     }
 
+    fn check_not_instruction(rule: Rule, program: &str) {
+        let res = parse(program)
+            .unwrap()
+            .into_inner()
+            .nth(1)
+            .unwrap()
+            .as_rule();
+        assert_ne!(rule, res)
+    }
+
     #[test]
     fn goto() {
         check_instruction(Rule::goto, "/")
@@ -248,9 +258,27 @@ mod tests {
     }
 
     #[test]
-    fn add() {
+    fn like_add() {
         check_instruction(Rule::add, "like");
+        check_instruction(Rule::add, "like at the start");
+        check_instruction(Rule::add, "at the end like");
+        check_instruction(Rule::add, "word like in the mix");
+        check_instruction(Rule::add, "word \"like\" in quotes");
+
+        check_not_instruction(Rule::add, "likes does not count");
+        check_not_instruction(Rule::add, "and not this either abdlikedef");
+    }
+
+    #[test]
+    fn as_add() {
         check_instruction(Rule::add, "as");
+        check_instruction(Rule::add, "as at the start");
+        check_instruction(Rule::add, "at the end as");
+        check_instruction(Rule::add, "word as in the mix");
+        check_instruction(Rule::add, "word \"as\" in quotes");
+
+        check_not_instruction(Rule::add, "ass does not count");
+        check_not_instruction(Rule::add, "and not this either abdasdef");
     }
 
     #[test]


### PR DESCRIPTION
before this commit, we allowed anything that contained 'like' or 'as', now we require the instruction to match the words 'like' and 'as', and nothing else.