### PR TITLE
Custom errors used / returned

### DIFF
--- a/ashpaper-bin/Cargo.toml
+++ b/ashpaper-bin/Cargo.toml
@@ -17,10 +17,8 @@ keywords = ["esolang", "esopo", "poetry", "interpreter", "cli"]
 name = "ashpaper"
 path = "src/main.rs"
 
-[dependencies.ashpaper]
-path = "../ashpaper"
-
 [dependencies]
+ashpaper = { path = "../ashpaper", version = "0.2.5"}
 clap = "2.33.0"
 log = "0.4.0"
 env_logger = "0.7.1"

--- a/ashpaper-bin/Cargo.toml
+++ b/ashpaper-bin/Cargo.toml
@@ -18,7 +18,7 @@ name = "ashpaper"
 path = "src/main.rs"
 
 [dependencies.ashpaper]
-version = "0.2.5"
+path = "../ashpaper"
 
 [dependencies]
 clap = "2.33.0"

--- a/ashpaper-bin/src/main.rs
+++ b/ashpaper-bin/src/main.rs
@@ -58,10 +58,8 @@ pub fn main() {
     let fname = matches.value_of("INPUT").unwrap();
     let contents = fs::read_to_string(fname).expect("Something went wrong reading input file!");
 
-    if let Ok(res) = ashpaper::program::execute(&contents) {
-        print!("{}", res);
-    } else {
-        // TODO: really need some helpful error reporting
-        eprintln!("Error executing program!");
+    match ashpaper::program::execute(&contents) {
+        Ok(res) => print!("{}", res),
+        Err(e) => eprintln!("{}", e),
     }
 }

--- a/ashpaper/src/error.rs
+++ b/ashpaper/src/error.rs
@@ -1,0 +1,57 @@
+// use nom::{error::ErrorKind, Err, Needed};
+use std::error;
+use std::fmt;
+use std::str;
+
+#[derive(PartialEq, Debug, Clone)]
+pub enum Error {
+    InputError(String),
+    ParseError(String),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Error::InputError(ref s) => write!(f, "{}", s),
+            Error::ParseError(ref s) => write!(f, "{}", s),
+        }
+    }
+}
+
+impl error::Error for Error {
+    fn description(&self) -> &str {
+        "AshPaper error"
+    }
+}
+
+// impl<'a> From<Err<(&'a [u8], ErrorKind)>> for Error {
+//     fn from(err: Err<(&[u8], ErrorKind)>) -> Self {
+//         match err {
+//             Err::Incomplete(n) => Error::from(n),
+//             Err::Error(e) => Error::from(e),
+//             Err::Failure(e) => Error::from(e),
+//         }
+//     }
+// }
+
+// impl<'a> From<(&'a [u8], ErrorKind)> for Error {
+//     fn from(err: (&[u8], ErrorKind)) -> Self {
+//         let string = format!(
+//             "Parsing error: {}\n {:?}",
+//             err.1.description(),
+//             str::from_utf8(err.0)
+//         );
+//         Error::ParseError(string)
+//     }
+// }
+
+// impl From<Needed> for Error {
+//     fn from(needed: Needed) -> Self {
+//         let string = match needed {
+//             Needed::Unknown => format!("Data error: insufficient size, expectation unknown"),
+//             Needed::Size(s) => format!("Data error: insufficient size, expected {} bytes", s),
+//         };
+
+//         Error::ParseIncomplete(string)
+//     }
+// }

--- a/ashpaper/src/error.rs
+++ b/ashpaper/src/error.rs
@@ -1,7 +1,5 @@
 use program::Rule;
-use std::error;
 use std::fmt;
-use std::str;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Error {

--- a/ashpaper/src/error.rs
+++ b/ashpaper/src/error.rs
@@ -40,5 +40,41 @@ impl From<std::io::Error> for Error {
 
 #[cfg(test)]
 mod tests {
-    // None of these errors should be possible... how can we "test" them?
+    use super::*;
+
+    #[test]
+    fn display() {
+        let parse = "parse error".to_string();
+        let input = "input error".to_string();
+        let progam = "program error".to_string();
+
+        assert_eq!(parse, format!("{}", Error::ParseError(parse.clone())));
+        assert_eq!(input, format!("{}", Error::ParseError(input.clone())));
+        assert_eq!(progam, format!("{}", Error::ParseError(progam.clone())));
+    }
+
+    #[test]
+    fn io_err() {
+        let err_str = "IO Errored!";
+        let error = std::io::Error::new(std::io::ErrorKind::Other, err_str);
+
+        assert_eq!(err_str.to_string(), format!("{}", Error::from(error)));
+    }
+
+    #[test]
+    fn pest_err() {
+        let err_str = " --> 1:1\n  |\n1 | \n  | ^---\n  |\n  = unexpected pop; expected push";
+
+        let input = "";
+        let pos = pest::Position::from_start(input);
+        let error = pest::error::Error::new_from_pos(
+            pest::error::ErrorVariant::ParsingError {
+                positives: vec![Rule::push],
+                negatives: vec![Rule::pop],
+            },
+            pos,
+        );
+
+        assert_eq!(err_str.to_string(), format!("{}", Error::from(error)));
+    }
 }

--- a/ashpaper/src/error.rs
+++ b/ashpaper/src/error.rs
@@ -1,12 +1,13 @@
-// use nom::{error::ErrorKind, Err, Needed};
+use pest;
+use::program;
 use std::error;
 use std::fmt;
 use std::str;
 
 #[derive(PartialEq, Debug, Clone)]
 pub enum Error {
-    InputError(String),
     ParseError(String),
+    InputError(String),
 }
 
 impl fmt::Display for Error {
@@ -24,15 +25,18 @@ impl error::Error for Error {
     }
 }
 
-// impl<'a> From<Err<(&'a [u8], ErrorKind)>> for Error {
-//     fn from(err: Err<(&[u8], ErrorKind)>) -> Self {
-//         match err {
-//             Err::Incomplete(n) => Error::from(n),
-//             Err::Error(e) => Error::from(e),
-//             Err::Failure(e) => Error::from(e),
-//         }
-//     }
-// }
+impl From<pest::error::Error<program::Rule>> for Error {
+    fn from(err: pest::error::Error<program::Rule>) -> Self {
+        match err.variant {
+            pest::error::ErrorVariant::ParsingError { .. } => {
+                Error::ParseError("TODO".to_string())
+                }
+            pest::error::ErrorVariant::CustomError { ref message } => {
+                Error::ParseError(message.to_string())
+            }
+        }
+    }
+}
 
 // impl<'a> From<(&'a [u8], ErrorKind)> for Error {
 //     fn from(err: (&[u8], ErrorKind)) -> Self {

--- a/ashpaper/src/error.rs
+++ b/ashpaper/src/error.rs
@@ -1,20 +1,21 @@
-use pest;
-use::program;
+use program::Rule;
 use std::error;
 use std::fmt;
 use std::str;
 
-#[derive(PartialEq, Debug, Clone)]
+#[derive(Debug)]
 pub enum Error {
     ParseError(String),
     InputError(String),
+    ProgramError(String),
 }
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Error::InputError(ref s) => write!(f, "{}", s),
             Error::ParseError(ref s) => write!(f, "{}", s),
+            Error::InputError(ref s) => write!(f, "{}", s),
+            Error::ProgramError(ref s) => write!(f, "{}", s),
         }
     }
 }
@@ -25,37 +26,19 @@ impl error::Error for Error {
     }
 }
 
-impl From<pest::error::Error<program::Rule>> for Error {
-    fn from(err: pest::error::Error<program::Rule>) -> Self {
-        match err.variant {
-            pest::error::ErrorVariant::ParsingError { .. } => {
-                Error::ParseError("TODO".to_string())
-                }
-            pest::error::ErrorVariant::CustomError { ref message } => {
-                Error::ParseError(message.to_string())
-            }
-        }
+impl From<pest::error::Error<Rule>> for Error {
+    fn from(err: pest::error::Error<Rule>) -> Self {
+        Error::ParseError(format!("{}", err))
     }
 }
 
-// impl<'a> From<(&'a [u8], ErrorKind)> for Error {
-//     fn from(err: (&[u8], ErrorKind)) -> Self {
-//         let string = format!(
-//             "Parsing error: {}\n {:?}",
-//             err.1.description(),
-//             str::from_utf8(err.0)
-//         );
-//         Error::ParseError(string)
-//     }
-// }
+impl From<std::io::Error> for Error {
+    fn from(err: std::io::Error) -> Self {
+        Error::InputError(format!("{}", err))
+    }
+}
 
-// impl From<Needed> for Error {
-//     fn from(needed: Needed) -> Self {
-//         let string = match needed {
-//             Needed::Unknown => format!("Data error: insufficient size, expectation unknown"),
-//             Needed::Size(s) => format!("Data error: insufficient size, expected {} bytes", s),
-//         };
-
-//         Error::ParseIncomplete(string)
-//     }
-// }
+#[cfg(test)]
+mod tests {
+    // None of these errors should be possible... how can we "test" them?
+}

--- a/ashpaper/src/error.rs
+++ b/ashpaper/src/error.rs
@@ -20,12 +20,6 @@ impl fmt::Display for Error {
     }
 }
 
-impl error::Error for Error {
-    fn description(&self) -> &str {
-        "AshPaper error"
-    }
-}
-
 impl From<pest::error::Error<Rule>> for Error {
     fn from(err: pest::error::Error<Rule>) -> Self {
         Error::ParseError(format!("{}", err))
@@ -49,8 +43,8 @@ mod tests {
         let progam = "program error".to_string();
 
         assert_eq!(parse, format!("{}", Error::ParseError(parse.clone())));
-        assert_eq!(input, format!("{}", Error::ParseError(input.clone())));
-        assert_eq!(progam, format!("{}", Error::ParseError(progam.clone())));
+        assert_eq!(input, format!("{}", Error::InputError(input.clone())));
+        assert_eq!(progam, format!("{}", Error::ProgramError(progam.clone())));
     }
 
     #[test]

--- a/ashpaper/src/error.rs
+++ b/ashpaper/src/error.rs
@@ -3,7 +3,7 @@ use std::error;
 use std::fmt;
 use std::str;
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Error {
     ParseError(String),
     InputError(String),

--- a/ashpaper/src/lib.rs
+++ b/ashpaper/src/lib.rs
@@ -71,6 +71,6 @@ extern crate pest;
 #[macro_use]
 extern crate pest_derive;
 extern crate wordsworth;
-pub mod program;
 mod error;
+pub mod program;
 pub use error::Error;

--- a/ashpaper/src/lib.rs
+++ b/ashpaper/src/lib.rs
@@ -72,3 +72,5 @@ extern crate pest;
 extern crate pest_derive;
 extern crate wordsworth;
 pub mod program;
+mod error;
+pub use error::Error;

--- a/ashpaper/src/program.rs
+++ b/ashpaper/src/program.rs
@@ -4,6 +4,7 @@ extern crate log;
 use pest::Parser;
 use std::io::{self, BufRead};
 use wordsworth;
+use super::error::Error;
 
 type Instructions<'a> = pest::iterators::Pair<'a, Rule>;
 
@@ -103,10 +104,6 @@ fn parse(line: &str) -> Result<Instructions, ()> {
 }
 
 // TODO: define actual error types instead of `()`
-// TODO (maybe?): instead of printing output of execution,
-// accumulate into a String which is returned in the Result.
-// This would make the output more useable via the API,
-// but I haven't read the paper yet so maybe that's a bad idea.
 pub fn execute(program: &str) -> Result<String, ()> {
     let cursor = io::Cursor::new(program);
     let lines = cursor.lines().map(|l| l.unwrap()).collect::<Vec<String>>();
@@ -172,6 +169,7 @@ pub fn execute(program: &str) -> Result<String, ()> {
                 _ => {}
             }
         }
+
         log::info!("{: <51} | {: ^4} | {: ^4} | {:^?}", instruction.as_str(), mem.register0, mem.register1, mem.stack);
 
         instruction_pointer += 1;

--- a/ashpaper/src/program.rs
+++ b/ashpaper/src/program.rs
@@ -96,15 +96,15 @@ impl Memory {
 }
 
 // TODO: define actual error types instead of `()`
-fn parse(line: &str) -> Result<Instructions, ()> {
+fn parse(line: &str) -> Result<Instructions, Error> {
     AshPaper::parse(Rule::program, line)
-        .map_err(|_| ())? // ignore pest's custom error type
+        .map_err(|e| Error::from(e))?
         .next()
-        .ok_or(())
+        .ok_or(Error::ParseError("No instructions in program".to_string()))
 }
 
 // TODO: define actual error types instead of `()`
-pub fn execute(program: &str) -> Result<String, ()> {
+pub fn execute(program: &str) -> Result<String, Error> {
     let cursor = io::Cursor::new(program);
     let lines = cursor.lines().map(|l| l.unwrap()).collect::<Vec<String>>();
 
@@ -115,7 +115,8 @@ pub fn execute(program: &str) -> Result<String, ()> {
     let instructions = lines
         .iter()
         .map(|line| parse(line))
-        .collect::<Result<Vec<Instructions>, _>>()?;
+        .collect::<Result<Vec<_>, _>>()?;
+
     let mut instruction_pointer: usize = 0;
 
     log::info!("{: <51} | {: ^4} | {: ^4} | {: ^7}", "instruction", "r0", "r1", "stack");

--- a/ashpaper/src/program.rs
+++ b/ashpaper/src/program.rs
@@ -451,4 +451,11 @@ how lovely can it be?
         let five_factorial_res = "120\n".to_string();
         assert_eq!(execute(&five_factorial), Ok(five_factorial_res));
     }
+
+    #[test]
+    fn logging() {
+        // everything should work as expected if logging is enabled.
+        std::env::set_var("RUST_LOG", "info");
+        factorial();
+    }
 }

--- a/ashpaper/src/program.rs
+++ b/ashpaper/src/program.rs
@@ -1,7 +1,7 @@
 extern crate log;
 extern crate pest;
 
-use super::error::Error;
+use error::Error;
 use pest::Parser;
 use std::io::{self, BufRead};
 use wordsworth;


### PR DESCRIPTION
Prior to this series of commits, we were throwing away any info related to possible failures. The changes in this PR wrap potential errors as custom AshPaper error types and return them rather than `()` on failure.